### PR TITLE
allowing language change

### DIFF
--- a/pong-game/frontend/nginx/spa_files/index.html
+++ b/pong-game/frontend/nginx/spa_files/index.html
@@ -24,9 +24,6 @@
 					<a class="nav-link" href="#leaderboard" data-i18n="leaderboard"><span data-i18n="leaderboard">Leaderboard</span></a>
 				</li>
 				<li class="nav-item">
-					<a class="nav-link" href="#settings" data-i18n="settings"><span data-i18n="settings">Settings</span></a>
-				</li>
-				<li class="nav-item">
 					<a class="nav-link" href="#profile" data-i18n="profile"><span data-i18n="profile">Profile</span></a>
 				</li>
 				<li class="nav-item">

--- a/pong-game/frontend/nginx/spa_files/javascript/404.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/404.js
@@ -1,4 +1,5 @@
 import { translations } from "./language_pack.js";
+import { getLanguageCookie } from "./fetch_request.js";
 
 export function set404View(contentContainer) {
 	const currentLanguage = getLanguageCookie() ||  "en";

--- a/pong-game/frontend/nginx/spa_files/javascript/app.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/app.js
@@ -80,9 +80,6 @@ export async function loadPage(page) {
 					// will not be necessary, maybe it will
 					setProfileView(contentContainer, data.alias);
 					break;
-				case "settings":
-					setSettingsView(contentContainer);
-					break;
 				case "friends":
 					setFriendsView(contentContainer);
 					break;

--- a/pong-game/frontend/nginx/spa_files/javascript/friends.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/friends.js
@@ -218,6 +218,8 @@ export async function setFriendsView(contentContainer) {
             await blockUser(newBlockUsername);
         }
 		renderBlockList();
+        renderSentRequests();
+        renderFriendRequests();
         renderFriends();
 	});
 

--- a/pong-game/frontend/nginx/spa_files/javascript/language_pack.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/language_pack.js
@@ -108,7 +108,10 @@ export const translations = {
 		requestDuel: "Send Duel Request",
 		accept: "Accept",
 		cancel: "Cancel",
-		block: "Block"
+		block: "Block",
+		friendRequestSent: "Friend request sent",
+		blockedByUser: "is blocking you",
+		blockingUser: "you are blocking",
 	},
 	fr: {
 		confirm: "",

--- a/pong-game/frontend/nginx/spa_files/javascript/login_html.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/login_html.js
@@ -35,7 +35,7 @@ async function loadHtml(url) {
 // }
 
 export function setLoginViewHtml(contentContainer) {
-	const currentLanguage = localStorage.getItem("language");
+	const currentLanguage = getLanguageCookie() || "en";
 	contentContainer.innerHTML = `
 			<h2 data-i18n="loginTitle">Login</h2>
 			<form id="loginForm">
@@ -59,6 +59,11 @@ export function setLoginViewHtml(contentContainer) {
 			<p>${translations[currentLanguage].noAccount}
 				<a href="#register" id="registerLink">${translations[currentLanguage].registerLink}</a>
 			</p>
+			<select id="languageSelect" class="form-select mt-2">
+				<option value="en" data-i18n="english">English</option>
+				<option value="fr" data-i18n="francais">Français</option>
+				<option value="pt" data-i18n="Português">Português</option>
+			</select>
 	`;
 }
 
@@ -84,7 +89,12 @@ export function setRegisterViewHtml(contentContainer) {
 					<p id="successMessage"></p>
 				</div>
 				<button type="submit" class="btn btn-primary" data-i18n="registerButton">Register</button>
-				<a href="#login" class="btn btn-primary" >Back to log in</button a>
-			</form>
+				<a href="#login" class="btn btn-primary">Back to log in</a>
+				</form>
+				<select id="languageSelect" class="form-select mt-2">
+					<option value="en" data-i18n="english">English</option>
+					<option value="fr" data-i18n="francais">Français</option>
+					<option value="pt" data-i18n="Português">Português</option>
+				</select>
 	`;
 }

--- a/pong-game/frontend/nginx/spa_files/javascript/login_login.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/login_login.js
@@ -4,6 +4,7 @@ import { setCustomValidation } from "./login_validations.js";
 import { showError } from "./login_validations.js";
 import { showSuccess } from "./login_validations.js";
 import { getLanguageCookie } from './fetch_request.js';
+import { setLanguageCookie } from "./fetch_request.js";
 //validations before sending to backend
 
 
@@ -78,6 +79,8 @@ async function verify2FAInBackend(user_id, otpCode) {
 //TO bipass 2fa error
 function setupLoginFormEventHandler() {
 	const loginForm = document.getElementById("loginForm");
+	const languageSelect = document.getElementById("languageSelect");
+	languageSelect.value = getLanguageCookie() || "en";
 	setCustomValidation("usernameInput");
 	setCustomValidation("passwordInput");
 	loginForm.addEventListener("submit", async (event) => {
@@ -109,7 +112,12 @@ function setupLoginFormEventHandler() {
 		} catch (error) {
 			showError('Login failed. Please try again.');
 		}
-	})
+	});
+	languageSelect.addEventListener("change", async (event) => {
+		const selectedLanguage = event.target.value;
+		setLanguageCookie(selectedLanguage);
+		loadPage("login");
+});
 }
 
 

--- a/pong-game/frontend/nginx/spa_files/javascript/login_register.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/login_register.js
@@ -5,6 +5,8 @@ import { setCustomValidation } from './login_validations.js';
 import { validatePasswordMatch } from './login_validations.js';
 import { validateProfilePicture } from './login_validations.js';
 import { getLanguageCookie } from './fetch_request.js';
+import { setLanguageCookie } from "./fetch_request.js";
+import { loadPage } from './app.js';
 ///////////////////// UI Helpers /////////////////////
 
 ///////////////////// API Calls /////////////////////
@@ -29,6 +31,8 @@ function setupRegisterFormEventHandler() {
 	validateProfilePicture();
 	validatePasswordMatch();
 	const registerForm = document.getElementById("registerForm");
+	const languageSelect = document.getElementById("languageSelect");
+	languageSelect.value = getLanguageCookie() || "en";
 	registerForm.addEventListener("submit", async (event) => {
 		event.preventDefault();
 		const username = document.getElementById('newUsername').value;
@@ -63,6 +67,11 @@ function setupRegisterFormEventHandler() {
 		} catch (error) {
 			showError('An error occurred. Please try again later.');
 		}
+	});
+	languageSelect.addEventListener("change", async (event) => {
+			const selectedLanguage = event.target.value;
+			setLanguageCookie(selectedLanguage);
+			loadPage("register");
 	});
 }
 

--- a/pong-game/frontend/nginx/spa_files/javascript/login_register.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/login_register.js
@@ -11,11 +11,11 @@ import { loadPage } from './app.js';
 
 ///////////////////// API Calls /////////////////////
 
-async function registerUserInBackend(username, password, email, alias) {
+async function registerUserInBackend(username, password, email, alias, language) {
     const response = await fetch('/api/user/register/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password, email, alias })
+        body: JSON.stringify({ username, password, email, alias, language})
     });
     return response;
 }
@@ -32,7 +32,8 @@ function setupRegisterFormEventHandler() {
 	validatePasswordMatch();
 	const registerForm = document.getElementById("registerForm");
 	const languageSelect = document.getElementById("languageSelect");
-	languageSelect.value = getLanguageCookie() || "en";
+	const language = getLanguageCookie() || "en";
+	languageSelect.value = language;
 	registerForm.addEventListener("submit", async (event) => {
 		event.preventDefault();
 		const username = document.getElementById('newUsername').value;
@@ -41,7 +42,7 @@ function setupRegisterFormEventHandler() {
 		const password = document.getElementById('newPasswordInput').value;
 		const profilePictureInput = document.getElementById("profilePictureInput");
 		try {
-			const response = await registerUserInBackend(username, password, email, alias);
+			const response = await registerUserInBackend(username, password, email, alias, language);
 			const data = await response.json();
 			if (response.ok) {
 				showSuccess('Success! User profile has been created, you can now log in.');

--- a/pong-game/frontend/nginx/spa_files/javascript/manage_social.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/manage_social.js
@@ -11,6 +11,7 @@ export function sendDuelRequest(friendUsername) {
 }
 
 export function confirmRemoveFriend(friendAlias) {
+    const currentLanguage = getLanguageCookie() ||  "en";
     const confirmation = confirm(
         `${translations[currentLanguage].validationRemovalFirst} ${friendAlias} ${translations[currentLanguage].validationRemovalSecond} ?`
     );
@@ -96,43 +97,49 @@ export async function unblockUser(blockedUser) {
 }
 
 export async function blockUser(newBlockUsername) {
-        let data;
-        console.log("going here");
-        try {
-            const body = JSON.stringify({ alias: newBlockUsername });
-            data = await fetchWithToken('/api/user/block-user/', body, 'POST');
-        } catch (error) {
-            console.log(error);
-            return;
-        }
-        if (data.detail === 'this user is already blocked') {
-            alert(`${newBlockUsername} ${translations[currentLanguage].alreadyBlock}.`);
-        } else if (data.detail === 'No CustomUser matches the given query.' ) {
-            alert(`${translations[currentLanguage].user} ${newBlockUsername} ${translations[currentLanguage].notFound}.`);
-        } else if (data.detail === 'you cannot befriend yourself' ) {
-            alert(`${translations[currentLanguage].okSasuke}`);
-        }
-    }
-    // renderBlockList();
-    // renderFriends();
+    const currentLanguage = getLanguageCookie() ||  "en";
 
-//REQUEST
-export async function addFriend(newfriend) {
-        let data;
-        try {
-            const body = JSON.stringify({ toAlias: newfriend });
-            data = await fetchWithToken('/api/user/send-friend-request/', body, 'POST');
-            // console.log("User data: ", data);
-        } catch (error) {
-            console.log(error);
-            return;
-        }
-        if (data.detail === 'Friend request was already sent.') {
-                    alert(`${newfriend} ${translations[currentLanguage].alreadyFriend}.`);
-        } else if (data.detail === 'No CustomUser matches the given query.' ) {
-            alert(`${translations[currentLanguage].user} ${newfriend} ${translations[currentLanguage].notFound}.`);
-        } else if (data.detail === 'you cannot befriend yourself' ) {
-            alert(`${translations[currentLanguage].lonelyTest}`);
-        }
+    let data;
+    console.log("going here");
+    try {
+        const body = JSON.stringify({ alias: newBlockUsername });
+        data = await fetchWithToken('/api/user/block-user/', body, 'POST');
+    } catch (error) {
+        console.log(error);
+        return;
     }
-    // renderSentRequests();
+    if (data.detail === 'this user is already blocked') {
+        alert(`${newBlockUsername} ${translations[currentLanguage].alreadyBlock}.`);
+    } else if (data.detail === 'No CustomUser matches the given query.' ) {
+        alert(`${translations[currentLanguage].user} ${newBlockUsername} ${translations[currentLanguage].notFound}.`);
+    } else if (data.detail === 'you cannot befriend yourself' ) {
+        alert(`${translations[currentLanguage].okSasuke}`);
+    }
+}
+
+export async function addFriend(newfriend) {
+    const currentLanguage = getLanguageCookie() ||  "en";
+
+    let data;
+    try {
+        const body = JSON.stringify({ toAlias: newfriend });
+        data = await fetchWithToken('/api/user/send-friend-request/', body, 'POST');
+        // console.log("User data: ", data);
+    } catch (error) {
+        console.log(error);
+        return;
+    }
+    if (data.detail === 'Friend request was already sent.') {
+        alert(`${newfriend} ${translations[currentLanguage].alreadyFriend}.`);
+    } else if (data.detail === 'No CustomUser matches the given query.' ) {
+        alert(`${translations[currentLanguage].user} ${newfriend} ${translations[currentLanguage].notFound}.`);
+    } else if (data.detail === 'you cannot befriend yourself' ) {
+        alert(`${translations[currentLanguage].lonelyTest}`);
+    } else if (data.detail === 'you are blocking this user' ) {
+        alert(`${newfriend} ${translations[currentLanguage].blockedByUser}`);
+    } else if (data.detail === 'this user is blocking you' ) {
+        alert(`${translations[currentLanguage].blockingUser} ${newfriend}`);
+    } else {
+        alert(`${translations[currentLanguage].friendRequestSent}`);
+    }
+}

--- a/pong-game/frontend/nginx/spa_files/javascript/personnal-data.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/personnal-data.js
@@ -131,6 +131,7 @@ export async function setPersonnalDataView(contentContainer) {
         try {
             await fetchWithToken('/api/user/change-alias/', JSON.stringify({ alias: newAlias }), 'POST');
             alert('Alias updated successfully!');
+            loadPage("personnal-data")
         } catch (error) {
             console.error(error);
             alert('Failed to update alias.');
@@ -142,6 +143,7 @@ export async function setPersonnalDataView(contentContainer) {
         try {
             await fetchWithToken('/api/user/change-email/', JSON.stringify({ email: newEmail }), 'POST');
             alert('Email updated successfully!');
+            loadPage("personnal-data")
         } catch (error) {
             console.error(error);
             alert('Failed to update email.');

--- a/pong-game/game-service/app/user_service/models.py
+++ b/pong-game/game-service/app/user_service/models.py
@@ -57,9 +57,6 @@ class CustomUser(AbstractUser):
     def is_pending(self, user):
          return FriendRequest.objects.filter(from_user=user, to_user=self).exists()
 
-    def is_blocked_by(self, user):
-        return self.is_blocked_by.filter(id=user.id).exists()
-
 class FriendRequest(models.Model):
     from_user = models.ForeignKey(
         CustomUser, related_name="from_user", on_delete=models.CASCADE

--- a/pong-game/game-service/app/user_service/models.py
+++ b/pong-game/game-service/app/user_service/models.py
@@ -15,6 +15,7 @@ class CustomUser(AbstractUser):
     class Language(models.TextChoices):
         FR = "fr", "French"
         EN = "en", "English"
+        PT = "pt", "Portuguese"
 
     alias = models.CharField(max_length=20, blank=False, unique=True)
     mmr = models.FloatField(default=1000)

--- a/pong-game/game-service/app/user_service/serializers.py
+++ b/pong-game/game-service/app/user_service/serializers.py
@@ -31,7 +31,7 @@ class UserSerializer(serializers.ModelSerializer):
 			"lossCount": {"read_only": True},
 			"blockList": {"read_only": True},
 			"friendList": {"read_only": True},
-			"language": {"read_only": True},
+			"language": {"required": False},
 			"avatar": {"required": False},
 		}
 

--- a/pong-game/game-service/app/user_service/urls.py
+++ b/pong-game/game-service/app/user_service/urls.py
@@ -22,14 +22,16 @@ urlpatterns = [
 	# user profile
 	path("getuser/", CurrentUserView.as_view(), name="get_user"),
 	path("update-username/", updateUsernameView.as_view(), name="update_user"),
-	path("change-password/", 
-	  PasswordChangeView.as_view(
-		  template_name="user_service/change_password.html",
-		  success_url="/api/user/change-password-done/" 
-	  ), 
-	  name="update_password"),
-	path("change-password-done/", PasswordChangeDoneView.as_view(), name="update_password_success"),
+	# path("change-password/", 
+	#   PasswordChangeView.as_view(
+	# 	  template_name="user_service/change_password.html",
+	# 	  success_url="/api/user/change-password-done/" 
+	#   ), 
+	#   name="update_password"),
+	# path("change-password-done/", PasswordChangeDoneView.as_view(), name="update_password_success"),
 	path("change-email/", changeEmailView.as_view(), name="email_change"),
+	path("change-password/", changePasswordView.as_view(), name="password_change"),
+	path("change-alias/", changeAliasView.as_view(), name="change_alias"),
     path("send-friend-request/", sendFriendRequestView.as_view(), name="add_friend"),
     path("get-friends/", getFriendsView.as_view(), name="get_friends"),
     path("get-profile/", getProfileView.as_view(), name="get_profile"),


### PR DESCRIPTION
I'm adding the personnal data information, 
With it, we can change the password, the alias, not the username, and the profile picture ( i still dont know how to get it properly tho) 
i've added a button for the loggin and register screen to change the language as well, 
Also i've corrected the block function and the loophole created when having invalid tokens.
the settings view was removed as i think we won't need it if we don't look for much more accessibilty,
to test it, you can create 2 profile, check when changing information, then check wehn changing language, add another user, block him, try some stuff, normally you shouldn't be abble to create multiple friends request and so.

Work to be done : Some pages refreshes are still missing, like when you change language from certain places, or when you change your profile alias. 
some translations, as well as the fetchwithtoken functions has to be changed so that we can return the response and analyse error more effectively ( probably)
leaderboard has to be done
