### PR TITLE
Game ws bringup

### DIFF
--- a/pong-game/docker-compose.yml
+++ b/pong-game/docker-compose.yml
@@ -80,15 +80,6 @@ services:
   #     retries: 3
   #   restart: unless-stopped
 
-  # two_fa:
-  #   container_name: 2fa
-  #   build: ./security/2fa
-  #   ports:
-  #     - "8082:8082"
-  #   networks:
-  #     - backend_net
-  #   restart: unless-stopped
-
   # Frontend Layer
   ## [Theo] & [Alex]
   nginx:
@@ -130,20 +121,6 @@ services:
       timeout: 2s
       retries: 1
     restart: unless-stopped
-
-  # spa:
-  #   container_name: spa
-  #   build:
-  #     context: ./frontend/spa
-  #   volumes:
-  #     - ./frontend:/app
-  #     - /app/node_modules
-  #   environment:
-  #     - REACT_APP_API_URL=http://localhost/api
-  #     - REACT_APP_WS_URL=ws://localhost/ws
-  #   networks:
-  #     - frontend_net
-  #   restart: unless-stopped
 
   # Auth Layer
   # auth_service:

--- a/pong-game/frontend/nginx/nginx.conf
+++ b/pong-game/frontend/nginx/nginx.conf
@@ -112,23 +112,24 @@ http {
 
         # WebSocket for game
         location /ws/ {
-            # Proxy to Django Channels
-            proxy_pass http://game_service:8001;
-            # WS specific settings
+            # Common WebSocket settings
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
-            # Additional headers for WS
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            # Timeout setting
-            proxy_read_timeout 86400;
-            proxy_send_timeout 86400;
-            # Added for better WS stability
-            # proxy_buffering off;
-            # proxy_cache off;
+            # Split to set different timeout
+            location /ws/chat-server/ {
+                proxy_pass http://game_service:8001;
+                proxy_read_timeout 3600s;
+            }
+            location /ws/game-server/ {
+                proxy_pass http://game_service:8001;
+                proxy_read_timeout 60s;
+                proxy_buffering off; # reduce latency for gameplay
+            }
         }
 
         ## [Close before product launch] The /app/ route is a temporary develop endpoint for direct access to backend interface

--- a/pong-game/frontend/nginx/nginx.conf
+++ b/pong-game/frontend/nginx/nginx.conf
@@ -55,11 +55,6 @@ http {
     ssl_certificate /etc/nginx/ssl/selfsigned.crt;
     ssl_certificate_key /etc/nginx/ssl/selfsigned.key;
 
-    # upstream app {
-    #     server game_service:8004;
-    #     keepalive 32;
-    # }
-
     server {
         listen 80;
         server_name localhost;
@@ -132,17 +127,17 @@ http {
             }
         }
 
-        ## [Close before product launch] The /app/ route is a temporary develop endpoint for direct access to backend interface
-        location /app/ {
-            proxy_pass http://game_service:8004/;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X_Forwarded-Proto $scheme;
-        }
+        # ## [Close before product launch] The /app/ route is a temporary develop endpoint for direct access to backend interface
+        # location /app/ {
+        #     proxy_pass http://game_service:8004/;
+        #     proxy_http_version 1.1;
+        #     proxy_set_header Upgrade $http_upgrade;
+        #     proxy_set_header Connection "upgrade";
+        #     proxy_set_header Host $host;
+        #     proxy_set_header X-Real-IP $remote_addr;
+        #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        #     proxy_set_header X_Forwarded-Proto $scheme;
+        # }
 
         location /static/ {
             alias /app/static/;
@@ -163,48 +158,6 @@ http {
             }
             return 200 "WAF Test Endpoint\n";
         }
-
-        # API routes
-        # location /api/ {
-        #     # Auth Service
-        #     location /api/auth/ {
-        #         set $upstream_auth "auth_service:8001";
-        #         proxy_pass http://$upstream_auth;
-        #     }
-
-        #     # User Service
-        #     location /api/users/ {
-        #         set $upstream_user "user_service:8002";
-        #         proxy_pass http://$upstream_user;
-        #     }
-
-        #     # Game Service
-        #     location /api/game/ {
-        #         set $upstream_game "game_service:8004";
-        #         proxy_pass http://$upstream_game;
-        #     }
-
-        #     # Common headers for all API routes
-        #     proxy_http_version 1.1; 
-        #     proxy_set_header Host $http_host;
-        #     proxy_set_header X-Real-IP $remote_addr;
-        #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        #     proxy_set_header X-Forwarded-Proto $scheme;
-        # }
-
-        # WebSocket for game
-        # location /ws/ {
-        #     set $upstream_game "game_service:8004";
-        #     proxy_pass http://$upstream_game;
-        #     proxy_http_version 1.1;
-        #     proxy_set_header Upgrade $http_upgrade;
-        #     proxy_set_header Connection "Upgrade";
-        #     proxy_set_header Host $http_host;
-        #     proxy_set_header X-Real-IP $remote_addr;
-        #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        #     proxy_set_header X-Forwarded-Proto $scheme;
-        #     proxy_read_timeout 86400;
-        # }
 
         # # Monitoring endpoints
         # location /grafana/ {

--- a/pong-game/game-service/app/backend/asgi.py
+++ b/pong-game/game-service/app/backend/asgi.py
@@ -12,7 +12,8 @@ from django.core.asgi import get_asgi_application
 from channels.auth import AuthMiddlewareStack
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.security.websocket import AllowedHostsOriginValidator
-import chat.routing
+from chat import routing as chat_routing
+from game_service import routing as game_routing
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'backend.settings')
 
@@ -23,7 +24,8 @@ application = ProtocolTypeRouter(
         "websocket": AllowedHostsOriginValidator(
             AuthMiddlewareStack(
                 URLRouter(
-                    chat.routing.websocket_urlpatterns
+                    chat_routing.websocket_urlpatterns +
+                    game_routing.websocket_urlpatterns
                 )
             )
         ),

--- a/pong-game/game-service/app/backend/settings.py
+++ b/pong-game/game-service/app/backend/settings.py
@@ -56,7 +56,6 @@ SIMPLE_JWT = {
 INSTALLED_APPS = [
     "daphne",
     "chat",
-    # "channels",
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',

--- a/pong-game/game-service/app/backend/urls.py
+++ b/pong-game/game-service/app/backend/urls.py
@@ -24,5 +24,6 @@ from django.contrib.auth import views as auth_views
 urlpatterns = [
     path('api/admin/', admin.site.urls),
     path("api/user/", include("user_service.urls")),
-    path("api/chat/", include("chat.urls"))
+    path("api/chat/", include("chat.urls")),
+    path("api/game/", include("game_service.urls"))
 ]

--- a/pong-game/game-service/app/chat/consumers.py
+++ b/pong-game/game-service/app/chat/consumers.py
@@ -1,9 +1,4 @@
 import json
-# from channels.generic.websocket import WebsocketConsumer
-# from asgiref.sync import async_to_sync
-
-# import json
-
 from channels.generic.websocket import AsyncWebsocketConsumer
 
 # You need to run this when using dev server: docker run --rm -p 6379:6379 redis:7 

--- a/pong-game/game-service/app/game_service/consumers.py
+++ b/pong-game/game-service/app/game_service/consumers.py
@@ -1,0 +1,34 @@
+import json
+from channels.generic.websocket import AsyncWebsocketConsumer
+
+class GameConsumer(AsyncWebsocketConsumer):
+    async def connect(self):
+        self.game_id = self.scope['url_route']['kwargs']['game_id']
+        self.game_group_name = f'game_{self.game_id}'
+        
+        await self.channel_layer.group_add(
+            self.game_group_name,
+            self.channel_name
+        )
+        await self.accept()
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(
+            self.game_group_name,
+            self.channel_name
+        )
+
+    async def receive(self, text_data):
+        data = json.loads(text_data)
+        await self.channel_layer.group_send(
+            self.game_group_name,
+            {
+                'type': 'game_message',
+                'message': data['message']
+            }
+        )
+
+    async def game_message(self, event):
+        await self.send(text_data=json.dumps({
+            'message': event['message']
+        }))

--- a/pong-game/game-service/app/game_service/routing.py
+++ b/pong-game/game-service/app/game_service/routing.py
@@ -1,0 +1,6 @@
+from django.urls import re_path
+from . import consumers
+
+websocket_urlpatterns = [
+    re_path(r"ws/game-server/(?P<game_id>\w+)/$", consumers.GameConsumer.as_asgi()),
+]

--- a/pong-game/game-service/app/game_service/templates/game_service/game_test.html
+++ b/pong-game/game-service/app/game_service/templates/game_service/game_test.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Game WebSocket Test</title>
+</head>
+<body>
+    <h1>Game ID: {{ game_id }}</h1>
+    <div id="game-log" style="height: 300px; overflow-y: scroll; border: 1px solid #ccc;"></div>
+    <input id="game-message" type="text">
+    <button onclick="sendMessage()">Send</button>
+
+    <script>
+        const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+        const wsUrl = `${wsScheme}://${window.location.host}/ws/game-server/{{ game_id }}/`;
+        const gameSocket = new WebSocket(wsUrl);
+
+        gameSocket.onmessage = function(e) {
+            const data = JSON.parse(e.data);
+            const log = document.getElementById('game-log');
+            log.innerHTML += `<p>${data.message}</p>`;
+            log.scrollTop = log.scrollHeight;
+        };
+
+        function sendMessage() {
+            const messageInput = document.getElementById('game-message');
+            gameSocket.send(JSON.stringify({
+                'message': messageInput.value
+            }));
+            messageInput.value = '';
+        }
+    </script>
+</body>
+</html>

--- a/pong-game/game-service/app/game_service/urls.py
+++ b/pong-game/game-service/app/game_service/urls.py
@@ -2,5 +2,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    # WS testing path
     path('test/<str:game_id>/', views.game_test, name='game_test'),
 ]

--- a/pong-game/game-service/app/game_service/urls.py
+++ b/pong-game/game-service/app/game_service/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('test/<str:game_id>/', views.game_test, name='game_test'),
+]

--- a/pong-game/game-service/app/game_service/views.py
+++ b/pong-game/game-service/app/game_service/views.py
@@ -1,3 +1,7 @@
 from django.shortcuts import render
 
 # Create your views here.
+def game_test(request, game_id):
+    return render(request, 'game_service/game_test.html', {
+        'game_id': game_id
+    })

--- a/pong-game/game-service/requirements.txt
+++ b/pong-game/game-service/requirements.txt
@@ -17,4 +17,3 @@ gunicorn==21.2.0
 better_profanity==0.7.0
 pillow==11.0.0
 uuid==1.30
-# channels==3.0.5


### PR DESCRIPTION
I did some study with Claude AI and confirmed that it is better to create dedicated WS for chat and game individually.

In this small PR, I expanded the settings in both nginx and Django backend, and created a test to demonstrate that both ws chat and ws game can be created.

To demo:
- visit `https://localhost:8443/api/chat/` to create chat WS
- visit `https://localhost:8443/api/game/test/game_id/` to create game WS

<img width="1428" alt="Screenshot 2024-12-09 at 22 06 27" src="https://github.com/user-attachments/assets/41988e1c-48ac-4b58-a83d-510d068ae38b">


@asut00 and @Atwazar: you guys can continue with the chat app and re-write chat.js to complete the frontend.
@Haliris: you can merge the settings of nginx and backend files to bring up your gaming part.
