### PR TITLE
adding pagination to leaderboard and searchbar

### DIFF
--- a/pong-game/frontend/nginx/spa_files/javascript/leaderboard.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/leaderboard.js
@@ -3,56 +3,90 @@ import { fetchWithToken, getLanguageCookie } from './fetch_request.js';
 import { loadPage } from './app.js';
 import { translations } from './language_pack.js';
 
-import { setContainerHtml } from './app.js'
 
 export async function setLeaderboardView(contentContainer) {
-	// await setContainerHtml(contentContainer, "./html/leaderboard.html");
-
 	contentContainer.innerHTML = `
 		<div class="leaderboard-view">
 			<h2 data-i18n="leaderboard">Leaderboard</h2>
+			<div class="filter-bar">
+				<input type="text" id="leaderboardFilterInput" class="form-control" placeholder="Search by username..." />
+			</div>
 			<table class="table">
 				<thead>
 					<tr>
 						<th>#</th>
 						<th data-i18n="username">Username</th>
-						<th >MMR</th>
+						<th>MMR</th>
 					</tr>
 				</thead>
 				<tbody id="leaderboardTableBody">
 				</tbody>
 			</table>
+			<nav>
+				<ul class="pagination" id="paginationContainer">
+				</ul>
+			</nav>
 		</div>
 	`;
-	let response;
-	try {
-		const response = await fetchWithToken('/api/game/leaderboard/');
-		const leaderboardData = await response.json();
-		console.log(leaderboardData);
-		populateLeaderboardTable(leaderboardData);
-	} catch (error) {
-		window.location.hash = "login";
-		console.log(error);
-		loadPage("login");
-		return;
+
+	let currentSearchQuery = "";
+	let currentPage = 1;
+
+	async function fetchLeaderboard(page = 1, searchQuery = "") {
+		try {
+			const response = await fetchWithToken(`/api/game/leaderboard/?page=${page}&search=${encodeURIComponent(searchQuery)}`);
+			const leaderboardData = await response.json();
+			populateLeaderboardTable(leaderboardData.leaderboard);
+			setupPagination(leaderboardData.totalPages, page);
+		} catch (error) {
+			console.error(error);
+			window.location.hash = "login";
+			loadPage("login");
+		}
 	}
-}
 
+	function populateLeaderboardTable(data) {
+		const tableBody = document.getElementById("leaderboardTableBody");
+		tableBody.innerHTML = "";
+		if (!data || data.length === 0) {
+			tableBody.innerHTML = `<tr><td colspan="3" class="text-muted" data-i18n="noData">No data available</td></tr>`;
+			return;
+		}
+		data.forEach((user) => {
+			const row = `
+				<tr>
+					<td>${user.rank}</td>
+					<td><a href="#profile/${user.alias}" class="profile-link">${user.alias}</a></td>
+					<td>${user.mmr}</td>
+				</tr>
+			`;
+			tableBody.innerHTML += row;
+		});
+	}
 
+	function setupPagination(totalPages, currentPage) {
+		const paginationContainer = document.getElementById("paginationContainer");
+		paginationContainer.innerHTML = "";
+		for (let i = 1; i <= totalPages; i++) {
+			const pageItem = document.createElement("li");
+			pageItem.className = `page-item ${i === currentPage ? "active" : ""}`;
+			pageItem.innerHTML = `<a class="page-link" href="#">${i}</a>`;
+			pageItem.addEventListener("click", (e) => {
+				e.preventDefault();
+				currentPage = i;
+				fetchLeaderboard(currentPage, currentSearchQuery);
+			});
+			paginationContainer.appendChild(pageItem);
+		}
+	}
 
-function populateLeaderboardTable(data) {
-	const tableBody = document.getElementById("leaderboardTableBody");
-	tableBody.innerHTML = "";
-	console.log(data.length);
-	data.forEach((user) => {
-		const row = `
-			<tr>
-				<td>${user.rank}</td>
-				<td><a href="#profile/${user.alias}" class="profile-link">${user.alias}</a></td>
-				<td>${user.mmr}</td>
-			</tr>
-		`;
-		tableBody.innerHTML += row;
+	document.getElementById("leaderboardFilterInput").addEventListener("input", (e) => {
+		currentSearchQuery = e.target.value;
+		currentPage = 1;
+		fetchLeaderboard(currentPage, currentSearchQuery);
 	});
+
+	fetchLeaderboard();
 }
+
 


### PR DESCRIPTION
curl --insecure -X POST "https://localhost:8443/api/user/save-match/" \
-H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzMzOTM1MjAyLCJpYXQiOjE3MzM5MzM0MDIsImp0aSI6IjM4YmJmMDMwNjViODQ0MmI5MmE1NTIyN2ViNzNmNzM5IiwidXNlcl9pZCI6MX0.N1T2m88Tdim-qOIgU-0U99WF1kSkEgAYc_9Pawn77v8" \
-H "Content-Type: application/json" \
-d '{"p1ID":1,"p2ID":5, "matchOutcome":1}'


this is the request to try the leaderboard.
I've added pagination in the learderboard view, it is set to 2 profile per pages because i didnt feel like creating 11 profile to check lol. 

also i've added a search bar in the leaderboard, like if you want to check only one profile. we don't have to keep it but i find it kinda cool.

going to work on chat now.