### PR TITLE
Added a SSR pong template

### DIFF
--- a/pong-game/backend/app/game_service/templates/game_service/game_test_ssr.html
+++ b/pong-game/backend/app/game_service/templates/game_service/game_test_ssr.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Pong Game SSR Test</title>
+    <style>
+        canvas {
+            border: 2px solid black;
+            margin: 20px auto;
+            display: block;
+            background-color: #f0f0f0;
+        }
+        #game-info {
+            text-align: center;
+            font-size: 24px;
+            margin-bottom: 20px;
+        }
+        #controls {
+            text-align: center;
+            margin-top: 20px;
+        }
+        #debug {
+            margin: 20px;
+            padding: 10px;
+            border: 1px solid #ccc;
+            font-family: monospace;
+        }
+        .score-display {
+            display: flex;
+            justify-content: space-around;
+            margin: 20px 0;
+            font-size: 32px;
+        }
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    {# Server-side rendered initial game state #}
+    <div id="game-container"
+            data-game-id="{{ game_id }}"
+            data-initial-state='{{ initial_state_json }}''>
+        <div id="game-info">Waiting for players to connect...</div>
+        
+        <div class="score-display">
+            <div class="score p1-score">{{ initial_state.score.p1 }}</div>
+            <div class="score p2-score">{{ initial_state.score.p2 }}</div>
+        </div>
+        
+        <canvas id="gameCanvas" width="800" height="600"></canvas>
+        
+        <div id="controls">
+            <button id="readyButton" class="hidden">Ready to Play</button>
+            <div class="instructions">
+                <p>Player 1: W (up) / S (down)</p>
+                <p>Player 2: ArrowUp (up) / ArrowDown (down)</p>
+            </div>
+        </div>
+        
+        <div id="debug"></div>
+    </div>
+
+    <script>
+        // Get initial state from server-rendered data
+        const gameContainer = document.getElementById('game-container');
+        const gameId = gameContainer.dataset.gameId;
+        const initialState = JSON.parse(gameContainer.dataset.initialState);
+
+        console.log('Parsed initial state:', initialState);
+        
+        const canvas = document.getElementById('gameCanvas');
+        const ctx = canvas.getContext('2d');
+        const gameInfo = document.getElementById('game-info');
+        const debugDiv = document.getElementById('debug');
+        const readyButton = document.getElementById('readyButton');
+        let playerId = null;
+        let lastGameState = initialState;  // Use server-provided initial state
+
+        function drawGame(gameState) {
+            if (!gameState || !gameState.paddles || !gameState.ball) {
+                console.error('Invalid game state:', gameState);
+                return;
+            }
+            // Clear canvas
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+            // Draw paddles
+            ctx.fillStyle = '#000000';
+            Object.entries(gameState.paddles).forEach(([pid, paddle]) => {
+                ctx.fillRect(paddle.x, paddle.y, paddle.width, paddle.height);
+            });
+
+            // Draw ball
+            const ball = gameState.ball;
+            ctx.beginPath();
+            ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+            ctx.fill();
+
+            // Update scores
+            if (gameState.score) {
+                document.querySelector('.p1-score').textContent = gameState.score.p1;
+                document.querySelector('.p2-score').textContent = gameState.score.p2;
+            }
+
+            // Draw center line
+            ctx.setLineDash([5, 15]);
+            ctx.beginPath();
+            ctx.moveTo(canvas.width / 2, 0);
+            ctx.lineTo(canvas.width / 2, canvas.height);
+            ctx.stroke();
+            ctx.setLineDash([]);
+        }
+
+        // Draw initial game state
+        drawGame(initialState);
+
+        // WebSocket setup
+        const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws';
+        const wsUrl = `${wsScheme}://${window.location.host}/ws/game-server/${gameId}/`;
+        const ws = new WebSocket(wsUrl);
+
+        // Track pressed keys
+        const keys = {
+            'w': false,
+            's': false,
+            'ArrowUp': false,
+            'ArrowDown': false
+        };
+
+        ws.onmessage = function(e) {
+            const data = JSON.parse(e.data);
+            debugDiv.textContent = 'Received message: ' + JSON.stringify(data, null, 2);
+
+            switch(data.type) {
+                case 'player_assignment':
+                    playerId = data.player_id;
+                    gameInfo.textContent = `You are Player ${playerId} - Get Ready!`;
+                    readyButton.classList.remove('hidden');
+                    break;
+
+                case 'player_status':
+                    const playerCount = data.count;
+                    gameInfo.textContent = `Players connected: ${playerCount}/2`;
+                    if (playerCount === 2) {
+                        readyButton.disabled = false;
+                    }
+                    break;
+
+                case 'player_ready_status':
+                    const readyPlayers = data.ready_players;
+                    if (readyPlayers.includes(playerId)) {
+                        readyButton.disabled = true;
+                        readyButton.textContent = 'Waiting for other player...';
+                    }
+                    break;
+
+                case 'game_start':
+                    gameInfo.textContent = 'Game Started!';
+                    readyButton.classList.add('hidden');
+                    break;
+
+                case 'game_state_update':
+                    lastGameState = data.game_state;
+                    drawGame(data.game_state);
+                    break;
+
+                case 'game_end':
+                    gameInfo.textContent = 'Game Ended: ' + data.message;
+                    readyButton.classList.remove('hidden');
+                    readyButton.disabled = false;
+                    readyButton.textContent = 'Ready to Play';
+                    break;
+
+                case 'error':
+                    gameInfo.textContent = 'Error: ' + data.message;
+                    break;
+            }
+        };
+
+        readyButton.addEventListener('click', function() {
+            ws.send(JSON.stringify({ type: 'player_ready' }));
+            this.disabled = true;
+            this.textContent = 'Waiting for other player...';
+        });
+
+        // Input handling
+        function handleMovement() {
+            if (!playerId || !ws || ws.readyState !== WebSocket.OPEN) return;
+
+            let shouldMove = false;
+            let direction = null;
+
+            if (playerId === 'p1') {
+                if (keys['w']) {
+                    direction = 'up';
+                    shouldMove = true;
+                }
+                if (keys['s']) {
+                    direction = 'down';
+                    shouldMove = true;
+                }
+            } else if (playerId === 'p2') {
+                if (keys['ArrowUp']) {
+                    direction = 'up';
+                    shouldMove = true;
+                }
+                if (keys['ArrowDown']) {
+                    direction = 'down';
+                    shouldMove = true;
+                }
+            }
+
+            if (shouldMove && direction) {
+                ws.send(JSON.stringify({ type: 'paddle_move', direction: direction }));
+            }
+        }
+
+        document.addEventListener('keydown', function(e) {
+            if (e.key in keys) {
+                keys[e.key] = true;
+                handleMovement();
+                e.preventDefault();
+            }
+        });
+
+        document.addEventListener('keyup', function(e) {
+            if (e.key in keys) {
+                keys[e.key] = false;
+                e.preventDefault();
+            }
+        });
+
+        setInterval(handleMovement, 16);
+
+        ws.onclose = function(e) {
+            gameInfo.textContent = 'Connection closed';
+        };
+
+        ws.onerror = function(e) {
+            gameInfo.textContent = 'Connection error';
+        };
+    </script>
+</body>
+</html>

--- a/pong-game/backend/app/game_service/urls.py
+++ b/pong-game/backend/app/game_service/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     # path('privateMatch.js', views.serve_js, {'file_path': 'privateMatch.js'}),
     # path('joinMatch.js', views.serve_js, {'file_path': 'joinMatch.js'}),
     path('test/', views.game_test, name='game_test'),
+    path('test_ssr/', views.game_test_ssr, name='game_test_ssr'),
     # path('test/<str:game_id>/', views.game_test, name='game_test'),
     ## ranking and leaderboard stuff
     path("matchHistory/", views.getMatchHistoryView.as_view(), name="match_history"),

--- a/pong-game/backend/app/game_service/views.py
+++ b/pong-game/backend/app/game_service/views.py
@@ -3,6 +3,8 @@ from django.http import JsonResponse
 from django.http import HttpResponse
 from django.conf import settings
 import os
+import json
+from django.utils.safestring import mark_safe
 
 from .models import MatchResults, LeaderBoard
 from user_service.models import CustomUser
@@ -52,6 +54,41 @@ from rest_framework.exceptions import ValidationError
 def game_test(request):
     return render(request, 'game_service/game_test.html', {
     })
+
+def game_test_ssr(request):
+	# Initial game state that will be pre-rendered
+	initial_state = {
+		'status': 'waiting',
+		'ball': {
+			'x': 400,
+			'y': 300,
+			'radius': 10
+        },
+		'paddles': {
+			'p1': {
+				'y': 250,
+				'x': 50,
+				'height': 100,
+				'width': 10
+            },
+			'p2': {
+				'y': 250,
+				'x': 740,
+				'height': 100,
+				'width': 10
+            }
+        },
+		'score': {
+			'p1': 0,
+			'p2': 0
+        }
+    }
+	context = {
+		'initial_state': initial_state,
+		'initial_state_json': mark_safe(json.dumps(initial_state)),
+		'game_id': 'test_game'
+    }
+	return render(request, 'game_service/game_test_ssr.html', context)
 
 ## Ranknig dashboard view.
 


### PR DESCRIPTION
It turns out the Server-Side Rendering (SSR) should only render the initial setting like the ball position and paddle position. The actual real-time game play should still render at client side. This way, the WS only send game_state instead of the hole buffer of pixels.

That is to say, the only thing to change to make CSR to SSR in pong-game is to add the default settings in the views.py, and that's it!

I added a template of game_test_ssr.html, which can be tested via `https://localhost:8443/api/game/test_ssr/`

@Haliris you can take this into consideration and decide which one you like to work on. FYI. For the scope of this Web pong-game, SSR and CSR won't affect the latency. The critical part is Server-side Pong-game which is what we are doing right now.

The latency you see when testing using two browsers could due
1. the task management when using browsers. idle browser will get less resource
2. currently the game_loop logic is started on player 1. This could be a issue to look after