### PR TITLE
Local/online games separation

### DIFF
--- a/pong-game/backend/app/game_service/consumers.py
+++ b/pong-game/backend/app/game_service/consumers.py
@@ -166,6 +166,7 @@ class GameConsumer(AsyncWebsocketConsumer):
 		active_lobbies[room_name] = {
 			"players": players,
 			"connection": [self],
+			"local": False,
 			"is_ai_game": True,
 			"difficulty": difficulty
 		}
@@ -189,10 +190,11 @@ class GameConsumer(AsyncWebsocketConsumer):
 		active_lobbies[room_name] = {
 				"players": players,
 				"connection": [],
-                "local": False,
-				"is_ai_game": False
+				"local": False,
+				"is_ai_game": False,
+				"difficulty": None
 				}
-		game_type = "Private Game"
+#		game_type = "Private Game" # Where the fuck does this come from??
 		await self.send(json.dumps({
 			"type": "room_creation",
 			"message": f"Created Lobby {room_name}",
@@ -207,7 +209,9 @@ class GameConsumer(AsyncWebsocketConsumer):
 			"players": [player_alias, player_2],
 			"ready": [player_2],
 			"connection": [self],
-			"local": True
+			"local": True,
+			"is_ai_game": False,
+			"difficulty": None
 		}
 		await self.send(json.dumps({
 			"type": "local_room_creation",
@@ -287,10 +291,10 @@ class GameConsumer(AsyncWebsocketConsumer):
 					"message": "Game is starting"
 					}))
 			logger.info(f"Starting game id: lobby_{room_name}")
-			if  active_lobbies[room_name]["is_ai_game"] == True:
-				game_room = GameRoom(room_name, active_lobbies[room_name]["players"], active_lobbies[room_name]["connection"], active_lobbies[room_name]["local"], active_lobbies[room_name]["difficulty"])
-			else:
-				game_room = GameRoom(room_name, active_lobbies[room_name]["players"], active_lobbies[room_name]["connection"], active_lobbies["local"], None)
+#			if  active_lobbies[room_name]["is_ai_game"] == True:
+#				game_room = GameRoom(room_name, active_lobbies[room_name]["players"], active_lobbies[room_name]["connection"], active_lobbies[room_name]["local"], active_lobbies[room_name]["difficulty"])
+#			else:
+			game_room = GameRoom(room_name, active_lobbies[room_name]["players"], active_lobbies[room_name]["connection"], active_lobbies[room_name]["local"], active_lobbies[room_name]["difficulty"])
 			logger.info("GameRoom created")
 			logger.info("Checking for local")
 			if active_lobbies[room_name]["local"] == True:

--- a/pong-game/backend/app/game_service/consumers.py
+++ b/pong-game/backend/app/game_service/consumers.py
@@ -15,7 +15,8 @@ from django.conf import settings
 
 
 load_dotenv()
-active_game_rooms = dict()
+active_online_games = dict()
+active_local_games = dict()
 active_lobbies = {}
 logger = logging.getLogger(__name__)
 
@@ -129,8 +130,8 @@ class GameConsumer(AsyncWebsocketConsumer):
 			await self.update_ready_status(data["room_name"], player_alias)
 		elif data.get('type') == "player_input":
 			roomID = data['game_roomID']
-			if roomID in active_game_rooms:
-				game_room = active_game_rooms[roomID]["room_data"]
+			if roomID in active_online_games:
+				game_room = active_online_games[roomID]["room_data"]
 				logger.info("Consumer: Received player input")
 				await game_room.receive_player_input(player_alias, data['input'])
 				logger.info("Consumer: Forwarded player input")
@@ -276,7 +277,7 @@ class GameConsumer(AsyncWebsocketConsumer):
 			logger.info(f"Starting game id: lobby_{room_name}")
 			game_room = GameRoom(room_name, active_lobbies[room_name]["players"], active_lobbies[room_name]["connection"])
 			logger.info("GameRoom created")
-			active_game_rooms[group_name] = {
+			active_online_games[group_name] = {
 				"room_data": game_room,
 				"player_data": {
 						"connection": active_lobbies[room_name]["connection"],
@@ -306,8 +307,8 @@ class GameConsumer(AsyncWebsocketConsumer):
 			raise
 		finally:
 			room_name = task.get_name()
-			if room_name in active_game_rooms:
-				del active_game_rooms[room_name]
+			if room_name in active_online_games:
+				del active_online_games[room_name]
 
 	def all_ready(self, room_name):
 		if room_name not in active_lobbies:
@@ -319,11 +320,11 @@ class GameConsumer(AsyncWebsocketConsumer):
 	#not implemented ahah
 	def cleanup_timed_out_rooms(self): #Potentially could be handled in handle_game_task_completion
 		rooms_to_remove = [
-				room_id for room_id, game_room in active_game_rooms.items()
+				room_id for room_id, game_room in active_online_games.items()
 				if game_room.has_timed_out() #decide whether the consumer or the game_room will track the time
 				]
 		for room_id in rooms_to_remove:
-			del active_game_rooms[room_id]
+			del active_online_games[room_id]
 
 	async def authenticate_user(self):
 		query_string = self.scope["query_string"].decode("utf-8")

--- a/pong-game/backend/app/game_service/game_room.py
+++ b/pong-game/backend/app/game_service/game_room.py
@@ -33,11 +33,12 @@ class Ball():
         self.radius = BALL_RADIUS
 
 class GameRoom():
-    def __init__(self, room_id, user_data, consumer_data):
+    def __init__(self, room_id, user_data, consumer_data, is_local):
         self.room_id = "lobby_" + room_id
         self.connections = []
         self.left_player = user_data[0]
         self.right_player = user_data[1]
+        self.is_local = is_local
 
         # Adding AI player logic
         self.ai_player = None
@@ -63,6 +64,9 @@ class GameRoom():
     def get_room_name(self):
         return self.room_id
 
+    def is_local_game(self):
+        return self.is_local
+
     async def receive_player_input(self, player_id, input):
         logger.info("GameRoom: Received player input")
         if player_id in self.players:
@@ -74,6 +78,7 @@ class GameRoom():
             elif input == "move_stop":
                 player.speed = 0
             elif input == "idle":
+                logger.info(f"GameRoom: ID NOT FOUND, current players: {self.left_player} {self.right_player}")
                 pass
 
     def update_players(self):

--- a/pong-game/backend/app/game_service/templates/game_service/game.html
+++ b/pong-game/backend/app/game_service/templates/game_service/game.html
@@ -106,6 +106,93 @@
 			}, {});
 			return cookies[name];
 		}
+
+		async function fetchWithToken(url, body = null, method = 'GET', needForContent = true) {
+			let token = getCookie("accessToken");
+			if (!token) {
+				throw new Error("No access token available.");
+			}
+
+		let hasTriedRefresh = false;
+
+		const fetchWithAccessToken = async (token) => {
+			const options = {
+				method: method,
+				headers: {
+					'Authorization': `Bearer ${token}`,
+				},
+			};
+
+			// this is just a desperate attempt to get the token right, doesn't work, doesn't do anythin, we might not need it
+			// if (method === 'POST') {
+			//     const csrfToken = getCookie("csrftoken");
+			//     if (csrfToken) {
+			// 		console.log("pls tell me we go here i beg you");
+			//         options.headers['X-CSRFToken'] = csrfToken;
+			//     } else {
+			//         console.error("CSRF token is missing");
+			//     }
+			// }
+
+			if (needForContent) {
+				options.headers['Content-Type'] = 'application/json';
+			}
+
+			if (body) {
+				options.body = body;
+			}
+
+			console.log(options);
+
+			const response = await fetch(url, options);
+			if (response.status === 401 && !hasTriedRefresh) {
+				console.log("Access token expired, attempting to refresh...");
+				hasTriedRefresh = true;
+
+				const refreshToken = getCookie("refreshToken");
+				if (!refreshToken) {
+					throw new Error("No refresh token available for renewal.");
+				}
+
+				const refreshResponse = await fetch('/api/user/token/refresh/', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ refresh: refreshToken }),
+				});
+
+				if (refreshResponse.ok) {
+					const refreshData = await refreshResponse.json();
+					document.cookie = `accessToken=${refreshData.access}; path=/; secure; SameSite=Strict`;
+					token = refreshData.access;
+
+					return fetchWithAccessToken(token);
+				} else {
+					console.error("Failed to refresh token:", await refreshResponse.text());
+					throw new Error("Failed to refresh token. Please log in again.");
+				}
+			} else if (response.status === 401 && hasTriedRefresh) {
+				throw new Error("Failed to refresh token. Please log in again.");
+			}
+			return response;
+		};
+
+		return fetchWithAccessToken(token);
+		}
+
+		var data = {
+			playerId: -1,
+			player2Id: -1,
+			socket: -1,
+			roomUID: -1
+		};
+
+		const async_wrapper = async() => {
+			const response = await fetchWithToken('/api/user/getuser/');
+			const response_data = await response.json();
+			data.playerId = response_data.alias
+		}
 		const canvas = document.getElementById('game');
 		const token = getCookie("accessToken");
 		const PADDLE_HEIGHT = 100;
@@ -280,6 +367,7 @@
 						type: 'player_input',
 						player_id: data.playerId,
 						input: playerEvent.type,
+						local: false,
 						game_roomID: data.roomUID
 					}));
 					playerEvent.pending = false;
@@ -289,6 +377,7 @@
 						type: 'player_input',
 						player_id: data.playerId,
 						input: 'idle',
+						local: false,
 						game_roomID: data.roomUID
 					}));
 				}
@@ -558,7 +647,6 @@
 			try {
 				ctx.clearRect(0, 0, canvas.width, canvas.height);
 				canvas.style.display = 'block';
-				data.playerId = 'player_1';
 				await data.socket.send(JSON.stringify({
 					action: 'create_ai_match',
 					id: data.playerId,
@@ -584,6 +672,7 @@
 			await connectWebSocket();
 		}
 
+		async_wrapper();
 		init();
 	</script>
 </body>

--- a/pong-game/backend/app/game_service/templates/game_service/solo_game.html
+++ b/pong-game/backend/app/game_service/templates/game_service/solo_game.html
@@ -61,6 +61,92 @@
 			return cookies[name];
 		}
 
+		async function fetchWithToken(url, body = null, method = 'GET', needForContent = true) {
+			let token = getCookie("accessToken");
+			if (!token) {
+				throw new Error("No access token available.");
+			}
+
+		let hasTriedRefresh = false;
+
+		const fetchWithAccessToken = async (token) => {
+			const options = {
+				method: method,
+				headers: {
+					'Authorization': `Bearer ${token}`,
+				},
+			};
+
+			// this is just a desperate attempt to get the token right, doesn't work, doesn't do anythin, we might not need it
+			// if (method === 'POST') {
+			//     const csrfToken = getCookie("csrftoken");
+			//     if (csrfToken) {
+			// 		console.log("pls tell me we go here i beg you");
+			//         options.headers['X-CSRFToken'] = csrfToken;
+			//     } else {
+			//         console.error("CSRF token is missing");
+			//     }
+			// }
+
+			if (needForContent) {
+				options.headers['Content-Type'] = 'application/json';
+			}
+
+			if (body) {
+				options.body = body;
+			}
+
+			console.log(options);
+
+			const response = await fetch(url, options);
+			if (response.status === 401 && !hasTriedRefresh) {
+				console.log("Access token expired, attempting to refresh...");
+				hasTriedRefresh = true;
+
+				const refreshToken = getCookie("refreshToken");
+				if (!refreshToken) {
+					throw new Error("No refresh token available for renewal.");
+				}
+
+				const refreshResponse = await fetch('/api/user/token/refresh/', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
+					body: JSON.stringify({ refresh: refreshToken }),
+				});
+
+				if (refreshResponse.ok) {
+					const refreshData = await refreshResponse.json();
+					document.cookie = `accessToken=${refreshData.access}; path=/; secure; SameSite=Strict`;
+					token = refreshData.access;
+
+					return fetchWithAccessToken(token);
+				} else {
+					console.error("Failed to refresh token:", await refreshResponse.text());
+					throw new Error("Failed to refresh token. Please log in again.");
+				}
+			} else if (response.status === 401 && hasTriedRefresh) {
+				throw new Error("Failed to refresh token. Please log in again.");
+			}
+			return response;
+		};
+
+		return fetchWithAccessToken(token);
+		}
+
+		var data = {
+			playerId: -1,
+			player2Id: -1,
+			socket: -1,
+			roomUID: -1
+		};
+
+		const async_wrapper = async() => {
+			const response = await fetchWithToken('/api/user/getuser/');
+			const response_data = await response.json();
+			data.playerId = response_data.alias
+		}
 		const canvas = document.getElementById('game');
 
 		const token = getCookie("accessToken");
@@ -121,13 +207,6 @@
 			ball: ball,
 			player1: Player,
 			player2: Player
-		};
-
-		var data = {
-			playerId: -1,
-			player2Id: -1,
-			socket: -1,
-			roomUID: -1
 		};
 
 		var game_over = false;
@@ -249,7 +328,8 @@
 						type: 'player_input',
 						player_id: playerEvent[property].id,
 						input: playerEvent[property].type,
-						game_roomID: data.roomUID
+						game_roomID: data.roomUID,
+						local: true
 					}));
 					playerEvent[property].pending = false;
 				}
@@ -258,7 +338,8 @@
 						type: 'player_input',
 						player_id: playerEvent[property].id,
 						input: 'idle',
-						game_roomID: data.roomUID
+						game_roomID: data.roomUID,
+						local: true
 					}));
 				}
 			}
@@ -398,7 +479,6 @@
 		async function create_local_match() {
 			try {
 				ctx.clearRect(0, 0, canvas.width, canvas.height);
-				data.playerId = 'player_1'
 				await request_local_room();
 				await showReadyButton()
 //				await startGame()
@@ -413,6 +493,7 @@
 			await connectWebSocket();
 		}
 
+		async_wrapper();
 		init();
 	</script>
 </body>

--- a/pong-game/frontend/nginx/spa_files/javascript/game_lobby.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_lobby.js
@@ -105,7 +105,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 			const gameId = 'test_game';
 			const wsScheme = window.location.protocol === 'https:' ? 'wss' : 'ws'; // to change to wss
 			const wsUrl = `${wsScheme}://${window.location.host}/ws/game-server/${gameId}/?token=${encodeURIComponent(token)}`;
-			
+
 			console.log('Connecting to WebSocket...')
 			ws = new WebSocket(wsUrl);
 			state.gameSocket = ws
@@ -184,8 +184,8 @@ export async function setLobbyView(contentContainer, roomID = "") {
 						} else if (response.type == 'error') {
 							console.error('Error received:', response.message);
 						} else if (response.type == 'game_update') {
-							if (pendingGameUpdate) { 
-								pendingGameUpdate(response.payload) 
+							if (pendingGameUpdate) {
+								pendingGameUpdate(response.payload)
 								pendingGameUpdate = null;
 							}
 						} else if (response.type == 'game_over') {
@@ -236,8 +236,9 @@ export async function setLobbyView(contentContainer, roomID = "") {
 				type: 'player_input',
 				player_id: data.playerId,
 				input: playerEvent.type,
-				game_roomID: data.roomUID
-			}));	
+				game_roomID: data.roomUID,
+				local: false
+			}));
 			playerEvent.pending = false;
 		}
 		else {
@@ -245,7 +246,8 @@ export async function setLobbyView(contentContainer, roomID = "") {
 				type: 'player_input',
 				player_id: data.playerId,
 				input: 'idle',
-				game_roomID: data.roomUID
+				game_roomID: data.roomUID,
+				local: false
 			}));
 		}
 	}
@@ -303,7 +305,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 	async function joinRoom(roomUID) {
 		try {
 			data.roomUID = roomUID;
-	
+
 			await state.gameSocket.send(JSON.stringify({
 				action: 'join_private_match',
 				room_name: roomUID,
@@ -320,11 +322,11 @@ export async function setLobbyView(contentContainer, roomID = "") {
 
 	async function showReadyButton() {
 		destroyReadyButton();
-	
+
 		readyButton = document.createElement('button');
 		readyButton.id = 'ready-button';
 		readyButton.textContent = 'Ready Up';
-		
+
 		readyButton.style.cssText = `
 			position: fixed;
 			bottom: 20px;
@@ -338,7 +340,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 			z-index: 1000;
 			border: 3px solid yellow;
 		`;
-	
+
 		readyButton.onclick = function(event) {
 			try {
 				if (readyButton.disabled == false) {
@@ -359,16 +361,16 @@ export async function setLobbyView(contentContainer, roomID = "") {
 				alert('Failed to send ready signal. Please try again.');
 			}
 		};
-	
+
 		readyButton.addEventListener('click', function(event) {
 			console.log('addEventListener triggered');
 			console.log('Event:', event);
 		});
-	
+
 		try {
 			document.body.appendChild(readyButton);
 			console.log('Ready button DEFINITELY added to DOM');
-			
+
 			const button = document.getElementById('ready-button');
 			if (button) {
 				console.log('Button found in DOM');
@@ -414,11 +416,11 @@ export async function setLobbyView(contentContainer, roomID = "") {
 			console.error('Exception caught in startGame', error);
 		}
 	}
-	
+
 
 	function renderUserInfo(user, targetId) {
 		const userInfoDiv = document.getElementById(targetId);
-	
+
 		userInfoDiv.innerHTML = `
 			<div style="display: flex; align-items: center; margin-bottom: 10px;">
 				<img src="${user.avatar}" alt="Avatar" style="width: 50px; height: 50px; border-radius: 50%; margin-right: 10px;">
@@ -428,7 +430,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 				</div>
 			</div>
 		`;
-	}	
+	}
 
 	async function create_private_match() {
 		try {
@@ -445,7 +447,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 		await connectWebSocket();
 		console.log("abruti");
 	}
-	
+
 	function getRoomIDInput() {
 		const modal = document.createElement('div');
 		modal.id = 'room-join-modal';
@@ -459,47 +461,47 @@ export async function setLobbyView(contentContainer, roomID = "") {
 		modal.style.backgroundColor = '#f9f9f9';
 		modal.style.boxShadow = '0 0 10px rgba(0, 0, 0, 0.1)';
 		modal.style.zIndex = '1000';
-	
+
 		modal.innerHTML = `
 			<h3>Join Game Room</h3>
-			<input 
-				type="text" 
-				id="room-uid-input" 
-				placeholder="Enter Room UID" 
+			<input
+				type="text"
+				id="room-uid-input"
+				placeholder="Enter Room UID"
 				style="width: 100%; padding: 10px; margin-bottom: 10px; box-sizing: border-box;"
 			>
-			<button 
-				id="join-room-btn" 
+			<button
+				id="join-room-btn"
 				style="width: 100%; padding: 10px; background-color: #4CAF50; color: white; border: none; border-radius: 5px; cursor: pointer;"
 			>
 				Join Room
 			</button>
 		`;
-	
+
 		document.body.appendChild(modal);
-	
+
 		const roomUidInput = modal.querySelector('#room-uid-input');
 		const joinRoomBtn = modal.querySelector('#join-room-btn');
-	
+
 		return new Promise((resolve, reject) => {
 			joinRoomBtn.addEventListener('click', () => {
 				const roomUID = roomUidInput.value.trim();
-	
+
 				if (!roomUID) {
 					alert('Please enter a valid Room UID.');
 					return;
 				}
-	
+
 				document.body.removeChild(modal);
 				resolve(roomUID);
 			});
 		});
-	}	
-	
+	}
+
 	document.getElementById('create-match').addEventListener('click', async () => {
 	create_private_match()
 });
-	
+
 	document.getElementById('join-match').addEventListener('click', async () => {
 		try {
 			const roomID = await getRoomIDInput();
@@ -508,7 +510,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 			console.error('Error in join-match event listener:', error);
 		}
 	});
-	
+
 	await init();
 	if (roomID) {
 		ctx.clearRect(0, 0, canvas.width, canvas.height);


### PR DESCRIPTION
Refactors consumer methods to fully separate local games from online games, this is to prevent a client running a local game from potentially being run in an online game instance of the server, in this scenario one player would be able to move the paddle of their opponent. 

Final PR for local games hopefully.

I noticed the game seems to be getting laggy AND sometimes the paddle get stuck moving in one direction despite the clients sending "move_stop" to the server, so something is not right, will investigate later.
