### PR TITLE
Tournament UX and display

### DIFF
--- a/pong-game/frontend/nginx/spa_files/javascript/game_lobby.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_lobby.js
@@ -28,7 +28,6 @@ export async function setLobbyView(contentContainer, roomID = "") {
 			<!-- <p>Select an option below to get started:</p> -->
 				<button id="create-match">Create Private Match</button>
 				<button id="join-match">Join Match</button>
-				<button id="ready-button" style="display:none;">Ready</button>
 				<button id="invite-button" style="display:none;"> > Invite a Player </button>
 				<div id="player-info-container" style="display: flex; justify-content: space-between;">
 					<div class="user-info" id="user-info-left" style="text-align: left; flex: 1; padding: 10px;"></div>
@@ -94,7 +93,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 	});
 
     document.getElementById('go-back-EOG').addEventListener('click', async () => {
-        window.location.hash = "game/";
+        window.location.hash = "lobby";
     });
 
 	setTypeOfGame("online");

--- a/pong-game/frontend/nginx/spa_files/javascript/game_lobby.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_lobby.js
@@ -23,9 +23,8 @@ export async function setLobbyView(contentContainer, roomID = "") {
 
 	contentContainer.innerHTML = `
 		<div class="gamelobby-view">
-		<!-- <h2>Game Lobby</h2> -->
-		<div id="game-lobby" class="gamelobby-view">
-			<!-- <p>Select an option below to get started:</p> -->
+			<div id="game-lobby" class="gamelobby-view">
+				<!-- <p>Select an option below to get started:</p> -->
 				<button id="create-match">Create Private Match</button>
 				<button id="join-match">Join Match</button>
 				<button id="invite-button" style="display:none;"> > Invite a Player </button>
@@ -37,6 +36,7 @@ export async function setLobbyView(contentContainer, roomID = "") {
 				<div id="player-status" class="player-status"></div>
 				<canvas id="game" width="800" height="600" style="display: none;"></canvas>
 				<button id="go-back-EOG" style="display: none;">${trslt[lng].back}</button>
+			</div>
 		</div>
 	`;
 	const canvas = document.getElementById('game');

--- a/pong-game/frontend/nginx/spa_files/javascript/game_local.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_local.js
@@ -5,6 +5,7 @@ import { state } from "./app.js";
 import { hideElem } from "./utils.js";
 import { showElem } from "./utils.js";
 import { setUpTwoPlayersControl, connectWebSocket, playerEvent, setTypeOfGame } from "./game_utils.js";
+import { translations as trslt } from "./language_pack.js";
 
 
 export async function setLocalLobby(contentContainer, skip = false) {
@@ -22,27 +23,26 @@ export async function setLocalLobby(contentContainer, skip = false) {
         window.location.hash = "login";
         return;
     }
+    const lng = getLanguageCookie() || "en";
     contentContainer.innerHTML = `
         <div class="gamelobby-view">
         <div id="game-lobby" class="gamelobby-view">
-            <div>
-                <button id="local">start local versus</button>
-                <button id="menu">Back To Menu</button>
-                <button id="ready-button" style="display:none;">Ready</button>
-                <div id="player-info-container" style="display: flex; justify-content: space-between;">
-                    <div id="user-info-left" style="text-align: left; flex: 1; padding: 10px;"></div>
-                    <div id="user-info-right" style="text-align: left; flex: 1; padding: 10px;"></div>
-                </div>
-                <div id="game-info">Loading...</div>
-                <div id="player-status" class="player-status"></div>
-                <canvas id="game" width="800" height="600" style="display: none;"></canvas>
+            <button id="local">Start local versus</button>
+            <button id="menu">${trslt[lng].back}</button>
+            <div id="player-info-container" style="display: flex; justify-content: space-between;">
+                <div id="user-info-left" style="text-align: left; flex: 1; padding: 10px;"></div>
+                <div id="user-info-right" style="text-align: left; flex: 1; padding: 10px;"></div>
             </div>
+            <div id="game-info">Loading...</div>
+            <div id="player-status" class="player-status"></div>
+            <canvas id="game" width="800" height="600" style="display: none;"></canvas>
+            <button id="go-back-EOG" style="display: none;">${trslt[lng].back}</button>
         </div>
     `;
+
     const canvas = document.getElementById('game');
     const ctx = canvas.getContext('2d');
     const gameInfo = document.getElementById('game-info');
-
 
     async function request_local_room() {
         try {
@@ -60,9 +60,7 @@ export async function setLocalLobby(contentContainer, skip = false) {
     async function create_local_match() {
         try {
             ctx.clearRect(0, 0, canvas.width, canvas.height);
-            canvas.style.display = 'block';
             await request_local_room();
-            gameInfo.textContent = 'Playing against your Friend - Get Ready!';
         } catch (error) {
             console.error('Error starting Local game:', error);
             gameInfo.textContent = 'Error starting Local game. Plase try again.';
@@ -75,19 +73,26 @@ export async function setLocalLobby(contentContainer, skip = false) {
     localButton.addEventListener('click', async () => {
         try {
             hideElem("local");
+            hideElem("menu");
             create_local_match();
         } catch (error) {
             console.error('Error in join-match event listener:', error);
         }
     });
     
-    document.getElementById('menu').addEventListener('click', async () => {
-        window.location.hash = "game/";
-    });
     await connectWebSocket();
     setUpTwoPlayersControl();
     if (skip) {
         hideElem("local");
         create_local_match();
     }
+    
+    document.getElementById('menu').addEventListener('click', async () => {
+        window.location.hash = "game/local";
+    });
+
+    document.getElementById('go-back-EOG').addEventListener('click', async () => {
+        window.location.hash = "game/local";
+    });
+
 }

--- a/pong-game/frontend/nginx/spa_files/javascript/game_local.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_local.js
@@ -28,7 +28,6 @@ export async function setLocalLobby(contentContainer, skip = false) {
         <div class="gamelobby-view">
         <div id="game-lobby" class="gamelobby-view">
             <button id="local">Start local versus</button>
-            <button id="menu">${trslt[lng].back}</button>
             <div id="player-info-container" style="display: flex; justify-content: space-between;">
                 <div id="user-info-left" style="text-align: left; flex: 1; padding: 10px;"></div>
                 <div id="user-info-right" style="text-align: left; flex: 1; padding: 10px;"></div>
@@ -39,6 +38,12 @@ export async function setLocalLobby(contentContainer, skip = false) {
             <button id="go-back-EOG" style="display: none;">${trslt[lng].back}</button>
         </div>
     `;
+
+    if (skip == true) {
+        console.log("SKIP IS TRUE");
+        document.getElementById('go-back-EOG').textContent = "";
+        hideElem("go-back-EOG");
+    }
 
     const canvas = document.getElementById('game');
     const ctx = canvas.getContext('2d');
@@ -73,7 +78,6 @@ export async function setLocalLobby(contentContainer, skip = false) {
     localButton.addEventListener('click', async () => {
         try {
             hideElem("local");
-            hideElem("menu");
             create_local_match();
         } catch (error) {
             console.error('Error in join-match event listener:', error);
@@ -87,10 +91,6 @@ export async function setLocalLobby(contentContainer, skip = false) {
         create_local_match();
     }
     
-    document.getElementById('menu').addEventListener('click', async () => {
-        window.location.hash = "game/local";
-    });
-
     document.getElementById('go-back-EOG').addEventListener('click', async () => {
         window.location.hash = "game/local";
     });

--- a/pong-game/frontend/nginx/spa_files/javascript/game_quickmatch.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_quickmatch.js
@@ -25,7 +25,6 @@ export async function setQuickMatchView(contentContainer, roomID = "") {
             <!-- <p>Select an option below to get started:</p> -->
             <div>
                 <button id="join-queue">Join Queue</button>
-                <button id="ready-button" style="display:none;">Ready</button>
                 <div id="player-info-container" style="display: flex; justify-content: space-between;">
                     <div id="user-info-left" style="text-align: left; flex: 1; padding: 10px;"></div>
                     <div id="user-info-right" style="text-align: left; flex: 1; padding: 10px;"></div>

--- a/pong-game/frontend/nginx/spa_files/javascript/game_solo.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_solo.js
@@ -6,9 +6,7 @@ import { hideElem, hideClass, showElem } from "./utils.js";
 import { translations as trslt } from "./language_pack.js";
 import { setUpOnePlayerControl, connectWebSocket, playerEvent, setTypeOfGame } from "./game_utils.js";
 
-
-
-export async function setSoloLobby(contentContainer, difficulty = "") {
+export async function setSoloLobby(contentContainer, difficulty = "", skip = false) {
     let response;
     let userData;
     try {
@@ -42,6 +40,13 @@ export async function setSoloLobby(contentContainer, difficulty = "") {
                 <button id="go-back-EOG" style="display: none;">${trslt[lng].back}</button>
         </div>
     `;
+
+    if (skip == true) {
+        console.log("SKIP IS TRUE");
+        document.getElementById('go-back-EOG').textContent = "";
+        hideElem("go-back-EOG");
+    }
+
     const canvas = document.getElementById('game');
     const ctx = canvas.getContext('2d');
     const gameInfo = document.getElementById('game-info');

--- a/pong-game/frontend/nginx/spa_files/javascript/game_tournament.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_tournament.js
@@ -20,7 +20,7 @@ export async function setTournamentView(contentContainer) {
 	if (userTournament) {
 		displayTournament(userTournament, tournamentStatusContainer);
 	} else {
-		tournamentStatusContainer.innerHTML = `<p>No tournament in progress.</p>`;
+		setTournamentViewForm(contentContainer);
 	}
 }
 

--- a/pong-game/frontend/nginx/spa_files/javascript/game_tournament.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_tournament.js
@@ -70,41 +70,66 @@ function displayTournament(tournament, container) {
 	});
 }
 
+function isPowerOf2(n) {
+    return Number.isInteger(n) &&(n > 0) && (n & (n - 1)) === 0;
+}
+
 function getPlayoffHtml(bracket) {
 	const n = bracket.players.length;
-	const html = `
-		<li class="matchup">
-			<span class="left-player">
-				<span style="color: ${
-					bracket.players[n - 2].result === "win" ? "green" : bracket.players[n - 2].result === "lose" ? "red" : "gray"
-				};">
-					${
-						bracket.players[n - 2].result === "win"
-						? "[W]"
-						: bracket.players[n - 2].result === "lose"
-						? "[L]"
-						: ""
-					}
+	const players = bracket.players;
+
+	let numOfQualified = 0;
+	while(!isPowerOf2(numOfQualified + ((n - numOfQualified)/2))) {
+		numOfQualified++;
+	}
+	let qualified = "Qualified: ";
+	let i = 0;
+	while (i < numOfQualified) {
+		if (i > 0) {
+			qualified += ', ';
+		}
+		qualified += `${players[i].alias}`;
+		i++;
+	}
+	let html = `<p class="qualified">${qualified}</p>`;
+	while (i < n - 1) {
+		html += `
+			<li class="matchup">
+				<span class="left-player">
+					<span style="color: ${
+						players[i].result === "win" ? "green" : players[i].result === "lose" ? "red" : "gray"
+					};">
+						${
+							players[i].result === "win"
+							? "[W]"
+							: players[i].result === "lose"
+							? "[L]"
+							: ""
+						}
+					</span>
+					${players[i].is_ai === "human" ? "" : "[CPU]"} ${players[i].alias}
+				</span>	
+				<span class="vs">| vs |</span>
+				<span class="right-player">
+					${players[i + 1].alias} ${players[i + 1].is_ai === "human" ? "" : "[CPU]"}
+					<span style="color: ${
+						players[i + 1].result === "win" ? "green" : players[i + 1].result === "lose" ? "red" : "gray"
+					};">
+						${
+							players[i + 1].result === "win"
+							? " [W]"
+							: players[i + 1].result === "lose"
+							? " [L]"
+							: ""
+						}
+					</span>
 				</span>
-				${bracket.players[n - 2].is_ai === "human" ? "" : "[CPU]"} ${bracket.players[n - 2].alias}
-			</span>	
-			<span class="vs">| vs |</span>
-			<span class="right-player">
-				${bracket.players[n - 1].alias} ${bracket.players[n - 1].is_ai === "human" ? "" : "[CPU]"}
-				<span style="color: ${
-					bracket.players[n - 1].result === "win" ? "green" : bracket.players[n - 1].result === "lose" ? "red" : "gray"
-				};">
-					${
-						bracket.players[n - 1].result === "win"
-						? " [W]"
-						: bracket.players[n - 1].result === "lose"
-						? " [L]"
-						: ""
-					}
-				</span>
-			</span>
-		</li>		
-	`;
+			</li>		
+		`;
+		i++;
+		i++;
+	}
+
 	return html;
 }
 
@@ -156,27 +181,23 @@ function getMatchupsHtml(bracket, index) {
 	const n = bracket.players.length;
 	console.log("number of player is : ", n);
 
+	// /!\ debug print, delete when pushing
+	// bracket.players.forEach((player, i) => { 
+	// 	console.log("player " + i + " is : ", player);
+	// })
+
 	// ODD < 7
-	// if we have an odd < 7 number of player in the bracket, for the first bracket, we just display a playoff between the two last players of the list
-	if (n % 2 != 0 && index == 0 && n < 7) {
-		console.log("WE HAVE AN ODD NUMBER OF PLAYERS BELOW 7");
-		html = getPlayoffHtml(bracket);
-		return html;
+	if (n % 2 != 0 && index == 0) {
+		return getPlayoffHtml(bracket);
 	}
 
 	// EVEN
-	// if we have an even number of players in the bracket, we iterate through the players 
-	// and display the even players on the left and odd players on the right
 	bracket.players.forEach((player, i) => {
-		// left player
 		if (i % 2 == 0) {
 			html += getLeftPlayerHtml(player);
-		}
-		// right player
-		else {
+		} else {
 			html += getRightPlayerHtml(player);
 		}
-		console.log("player " + i + " is : ", player);
 	})
 	return html;
 }

--- a/pong-game/frontend/nginx/spa_files/javascript/game_tournament.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_tournament.js
@@ -1,18 +1,17 @@
-import { fetchWithToken } from "./fetch_request.js";
+import { fetchWithToken, getLanguageCookie } from "./fetch_request.js";
 import { setLocalLobby } from "./game_local.js";
 import { setIsTournament } from "./game_utils.js";
 import { hideElem } from "./utils.js";
 import { TournamentPlayers } from "./game_utils.js";
 import { setSoloLobby } from "./game_solo.js";
+import { translations as trslt } from "./language_pack.js";
 
 
 export async function setTournamentView(contentContainer) {
 	setIsTournament(true);
 	contentContainer.innerHTML = `
-	<div id="tournament-view">
-		<h2>Tournament Dashboard</h2>
-		<div id="tournament-status">
-		</div>
+	<div class="tournament-view" id="tournament-view">
+		<div id="tournament-status"></div>
 		<button id="create-tournament-btn">Create New Tournament</button>
 		<div id="match-container">
 	</div>
@@ -35,13 +34,15 @@ export async function setTournamentView(contentContainer) {
 }
 
 function displayTournament(tournament, container) {
+	const lng = getLanguageCookie() ||  "en";
 	if (!container) return;
 
 	container.innerHTML = `
 		<h3>Tournament: ${tournament.name}</h3>
-		<p>Owner: ${tournament.user}</p>
+		<!-- <p>Owner: ${tournament.user}</p> -->
+		<button id="go-back-EOG" style="display: none;">${trslt[lng].back}</button>
 		<div id="brackets-container"></div>
-		<button id="next-match-btn">Afficher le prochain match</button>
+		<button id="next-match-btn">Start next game</button>
 		<div id="match-container"></div>
 	`;
 
@@ -86,16 +87,15 @@ function displayTournament(tournament, container) {
 
 function setTournamentViewForm(contentContainer) {
 	contentContainer.innerHTML = `
-	<div id="tournament-creation">
-		<h2>Create a Tournament</h2>
+	<div class="tournament-view" id="tournament-creation">
 		<form id="tournament-form">
 			<div>
-				<label for="tournament-name">Tournament Name:</label>
-				<input type="text" id="tournament-name" name="tournamentName" required />
+				<input type="text" id="tournament-name" name="tournamentName" placeholder="Enter tournament name" required />
 			</div>
+			<hr>
 			<div id="players-container">
 				<div class="player-entry">
-					<input type="text" placeholder="Alias" name="player1" required />
+					<input type="text" placeholder="Enter player 1 alias" name="player1" required />
 					<select name="type1">
 						<option value="human">Human</option>
 						<option value="easy">AI - Easy</option>
@@ -104,7 +104,7 @@ function setTournamentViewForm(contentContainer) {
 					</select>
 				</div>
 				<div class="player-entry">
-					<input type="text" placeholder="Alias" name="player2" required />
+					<input type="text" placeholder="Enter player 2 alias" name="player2" required />
 					<select name="type2">
 						<option value="human">Human</option>
 						<option value="easy">AI - Easy</option>
@@ -235,8 +235,8 @@ function setupTournamentForm(contentContainer) {
 		const playerEntry = document.createElement("div");
 		playerEntry.classList.add("player-entry");
 		playerEntry.innerHTML = `
-			<input type="text" placeholder="Alias" name="player${playerCount}" required />
-			<select name="type${playerCount}">
+			<input type="text" placeholder="Enter player ${playerCount} alias" name="player${playerCount}" required />
+			<select id="added-player" name="type${playerCount}">
 				<option value="human">Human</option>
 				<option value="easy">AI - Easy</option>
 				<option value="medium">AI - Medium</option>

--- a/pong-game/frontend/nginx/spa_files/javascript/game_utils.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_utils.js
@@ -14,6 +14,7 @@ let pendingGameUpdate = null;
 let roomId;
 let typeOfGame;
 let isTournament;
+
 export let TournamentPlayers = {
 	player1: {
 		alias: "none",
@@ -44,6 +45,7 @@ export function setIsTournament(isTournamentValue) {
 export function setTypeOfGame(gameType) {
 	typeOfGame	= gameType;
 }
+
 export function setRoomId(roomIdToJoin) {
 	roomId = roomIdToJoin;
 }
@@ -367,7 +369,7 @@ async function register_ai_room(response) {
 	if (isTournament) {
 		renderLocalUsers(TournamentPlayers.player1.alias, TournamentPlayers.player2.alias);
 	} else {
-		renderLocalUsers(response.player1_alias, "Mode: " + response.difficulty);
+		renderLocalUsers(response.player1_alias, "CPU [" + response.difficulty + "]");
 	}
 	await showReadyButton(roomId, playerEvent.player_1.id);
 }
@@ -530,12 +532,13 @@ export async function connectWebSocket() {
 
 async function startGame() {
 	try {
+		destroyReadyButton();
+		hideElem("ready-button");
+		showElem("game", "block");
+		showElem("go-back-EOG", "block");
+		hideClass("hrs");
+		hideElem("game-info");
 		if (typeOfGame !== "local") {
-			destroyReadyButton();
-			hideClass("hrs");
-			hideElem("game-info");
-			showElem("game", "block");
-			showElem("go-back-EOG", "block");
 			if (typeOfGame == "online") {
 				hideElem("invite-button");
 			}
@@ -553,7 +556,7 @@ export function renderLocalUsers(user1, user2) {
 		<h4>Player one</h4>
 		<div style="display: flex; align-items: center; margin-bottom: 10px;">
 			<div>
-				<p style="margin: 0; font-weight: bold;">${user1}</p>
+				<p style="margin: 0; padding: 0; font-weight: bold;">${user1}</p>
 			</div>
 		</div>
 		<hr class="hrs">
@@ -564,7 +567,7 @@ export function renderLocalUsers(user1, user2) {
 		<h4 class="player-two">Player two</h4>
 		<div style="display: flex; align-items: center; justify-content: right; margin-bottom: 10px;">
 			<div>
-				<p style="margin: 0; text-align: right; font-size: 0.8rem;">${user2}</p>
+				<p style="margin: 0; padding: 0; font-weight: bold; text-align: right;">${user2}</p>
 			</div>
 		</div>
 		<hr class="hrs">

--- a/pong-game/frontend/nginx/spa_files/javascript/game_utils.js
+++ b/pong-game/frontend/nginx/spa_files/javascript/game_utils.js
@@ -312,7 +312,7 @@ export function renderUserInfo(user1, user2 = null) {
 		userInfoRightDiv.innerHTML = `
 			<hr class="hrs">
 			<h4 class="player-two">Player two</h4>
-			<div style="display: flex; align-items: center; margin-bottom: 10px;">
+			<div style="display: flex; align-items: center; justify-content: right; margin-bottom: 10px;">
 				<div>
 					<p style="margin: 0; font-weight: bold;">${user2.alias}</p>
 					<p style="margin: 0; font-size: 0.8rem;">MMR: ${user2.mmr}</p>
@@ -325,7 +325,7 @@ export function renderUserInfo(user1, user2 = null) {
 		userInfoRightDiv.innerHTML = `
 			<hr>
 			<h4 class="player-two">Player two</h4>
-			<div style="display: flex; align-items: center; margin-bottom: 10px;">
+			<div style="display: flex; align-items: center; justify-content: right; margin-bottom: 10px;">
 				<div>
 					<p style="margin: 0; font-weight: bold;">Waiting...</p>
 				</div>
@@ -574,4 +574,10 @@ export function renderLocalUsers(user1, user2) {
 	`;
 	showElem("user-info-left", "block");
 	showElem("user-info-right", "block");
+}
+
+export function goBackButtonEventListener(location) {
+	document.getElementById('go-back-EOG').addEventListener('click', async () => {
+        window.location.hash = location;
+    });
 }

--- a/pong-game/frontend/nginx/spa_files/styles.css
+++ b/pong-game/frontend/nginx/spa_files/styles.css
@@ -610,6 +610,64 @@ canvas {
 	font-size: 1rem !important;
 }
 
+/**************************** Tournament ****************************/
+
+.tournament-view {
+	padding-top: 10px;
+	padding-bottom: 10px;
+	width: 100%;
+	padding-left: 10%;
+	padding-right: 10%;
+	height: var(--inner-view-height);
+	overflow-y: auto;
+	box-sizing: border-box; 
+}
+
+.tournament-view h3 {
+	padding: 10px 0px 10px 0px !important;
+}
+
+.player-entry {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+	gap: 5px;
+	padding: 10px 0 5px 0;
+}
+
+.player-entry input {
+	margin: 0px !important;
+	box-sizing: border-box;
+}
+
+.player-entry select {
+	width: 100px;
+	height: 35px;
+	font-size: 0.8rem;
+	margin: 0px;
+	background-color: rgba(209, 209, 209, 0.1);
+	border: 1px solid rgba(0, 0, 0, 0.1);
+	border-radius: 5px;
+}
+
+#added-player { /* added player select */
+	width: 78px;
+}
+
+.player-entry button {
+	width: 20px !important;
+	height: 35px !important;
+	font-size: 0.8rem !important;
+	margin: 0px !important;
+	padding: 0px !important;
+	background-color: transparent !important;
+}
+
+/**Tournament integrated game view */
+#match-container .gamelobby-view {
+	padding: 0 !important;
+}
+
 /**************************** Leaderboard ****************************/
 
 .leaderboard-view {

--- a/pong-game/frontend/nginx/spa_files/styles.css
+++ b/pong-game/frontend/nginx/spa_files/styles.css
@@ -554,7 +554,7 @@ canvas {
 
 #player-info-container {
 	width: 100%;
-	padding-top: 10px;
+	/* padding-top: 10px; */
 }
 
 .user-info {
@@ -608,12 +608,12 @@ canvas {
 #go-back-EOG {
 	text-align: right !important;
 	font-size: 1rem !important;
+	background-color: transparent !important;
 }
 
 /**************************** Tournament ****************************/
 
 .tournament-view {
-	padding-top: 10px;
 	padding-bottom: 10px;
 	width: 100%;
 	padding-left: 10%;
@@ -624,7 +624,8 @@ canvas {
 }
 
 .tournament-view h3 {
-	padding: 10px 0px 10px 0px !important;
+	padding: 10px 0px 0px 0px !important;
+	text-align: center;
 }
 
 .player-entry {
@@ -663,9 +664,71 @@ canvas {
 	background-color: transparent !important;
 }
 
+/** Tournament matchup display */
+
+.bracket h4 {
+	text-align: center;
+	padding-bottom: 0;
+}
+
+.bracket ul {
+	padding: 0 !important;
+}
+
+.matchup {
+    display: flex;
+    justify-content: space-between;
+	position: relative;
+    align-items: center;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+	margin-bottom: 10px;
+	font-size: 0.9rem;
+}
+
+.matchup .left-player,
+.matchup .right-player {
+    flex: 1;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+}
+
+.matchup .left-player {
+	justify-content: right;
+	text-align: right;
+	padding-right: 50px;
+}
+
+.matchup .right-player {
+	justify-content: left;
+	text-align: left;
+	padding-left: 50px;
+}
+
+.matchup span {
+	padding-left: 2px;
+	padding-right: 2px;
+}
+
+.vs {
+    font-weight: bold;
+    font-size: 1rem;
+    color: #555;
+	position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
+}
+
 /**Tournament integrated game view */
 #match-container .gamelobby-view {
 	padding: 0 !important;
+	padding-left: 5% !important;
+	padding-right: 5% !important;
+	height: 450px !important;
+	overflow-y: hidden !important;
 }
 
 /**************************** Leaderboard ****************************/


### PR DESCRIPTION
Mainly : 
- Fixing the remaining display bugs for all game modes apart from the tournament. All these game modes should now be ready-ish.
- Updating the tournament UX and display : 
    - Updated the create tournament page
    - In tournament, Games and matchups display are now 2 different displays
    - Setup a matchup display showing the matchups in the ongoing bracket

⚠️ The matchup display is currently not functionning when the number of players is odd and higher than 5. That's the next thing on the to do list.

Next steps : 
- Fixing the tournament display when more than 5 odd players
- Update the menu tree to simplify and avoid useless steps / pages with only one button
- Possibility to see the upcoming matchups in the next bracket when we just finished the current bracket ?