### PR TITLE
Fix crash when running multiple local or ai game rooms

### DIFF
--- a/pong-game/backend/app/game_service/consumers.py
+++ b/pong-game/backend/app/game_service/consumers.py
@@ -110,7 +110,6 @@ class GameConsumer(AsyncWebsocketConsumer):
 	async def check_for_existing_room(self):
 		for stray_room_id, room_data in active_online_games.items():
 			player_ids = room_data["player_data"]["ids"]
-			print(f"player_id: {player_ids}")
 			if self.user.id in player_ids:
 				index = player_ids.index(self.user.id)
 				if self.user.id is not room_data['room_data'].get_missing_player_id():

--- a/pong-game/backend/app/game_service/consumers.py
+++ b/pong-game/backend/app/game_service/consumers.py
@@ -110,8 +110,9 @@ class GameConsumer(AsyncWebsocketConsumer):
 	async def check_for_existing_room(self):
 		for stray_room_id, room_data in active_online_games.items():
 			player_ids = room_data["player_data"]["ids"]
-			index = player_ids.index(self.user.id)
+			print(f"player_id: {player_ids}")
 			if self.user.id in player_ids:
+				index = player_ids.index(self.user.id)
 				if self.user.id is not room_data['room_data'].get_missing_player_id():
 					logger.warning(f"{self.user.id}: User found to be already connected to active gameRoom")
 					await self.send(json.dumps({


### PR DESCRIPTION
Fix stupid crash caused by an unprotected memory access in check_for_existing_room() in gameConsumer